### PR TITLE
Add test suite for chicle functions

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+# chicle test suite
+# Requires: expect (for interactive tests)
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/chicle.sh"
+
+PASS=0
+FAIL=0
+
+pass() {
+  echo "  ✓ $1"
+  ((++PASS))
+}
+
+fail() {
+  echo "  ✗ $1"
+  echo "    Expected: $2"
+  echo "    Got:      $3"
+  ((++FAIL))
+}
+
+# Strip ANSI escape codes and carriage returns from expect output
+clean_output() {
+  perl -pe 's/\e\[[0-9;?]*[a-zA-Z]//g' | tr -d '\r'
+}
+
+# ============================================================================
+# Non-interactive tests (output capture)
+# ============================================================================
+
+echo "Testing chicle_style..."
+
+output=$(chicle_style --bold "hello")
+expected=$'\033[1mhello\033[0m'
+[[ "$output" == "$expected" ]] && pass "--bold" || fail "--bold" "$expected" "$output"
+
+output=$(chicle_style --dim "hello")
+expected=$'\033[2mhello\033[0m'
+[[ "$output" == "$expected" ]] && pass "--dim" || fail "--dim" "$expected" "$output"
+
+output=$(chicle_style --cyan "hello")
+expected=$'\033[36mhello\033[0m'
+[[ "$output" == "$expected" ]] && pass "--cyan" || fail "--cyan" "$expected" "$output"
+
+output=$(chicle_style --green "hello")
+expected=$'\033[32mhello\033[0m'
+[[ "$output" == "$expected" ]] && pass "--green" || fail "--green" "$expected" "$output"
+
+output=$(chicle_style --yellow "hello")
+expected=$'\033[33mhello\033[0m'
+[[ "$output" == "$expected" ]] && pass "--yellow" || fail "--yellow" "$expected" "$output"
+
+output=$(chicle_style --red "hello")
+expected=$'\033[31mhello\033[0m'
+[[ "$output" == "$expected" ]] && pass "--red" || fail "--red" "$expected" "$output"
+
+output=$(chicle_style --bold --cyan "hello")
+expected=$'\033[1m\033[36mhello\033[0m'
+[[ "$output" == "$expected" ]] && pass "--bold --cyan" || fail "--bold --cyan" "$expected" "$output"
+
+
+echo "Testing chicle_rule..."
+
+# Mock tput cols to return 10
+output=$(COLUMNS=10 chicle_rule 2>/dev/null || chicle_rule)
+# chicle_rule uses tput cols, so we check it contains the right char
+[[ "$output" == *"─"* ]] && pass "contains line char" || fail "contains line char" "─" "$output"
+
+output=$(chicle_rule --char "=")
+[[ "$output" == *"="* ]] && pass "--char =" || fail "--char =" "=" "$output"
+
+
+# ============================================================================
+# Interactive tests (expect)
+# ============================================================================
+
+if command -v expect &>/dev/null && command -v perl &>/dev/null; then
+  echo "Testing chicle_choose (expect)..."
+
+  # Test: select first item (just press enter)
+  output=$(expect -c '
+    spawn bash -c "source '"$SCRIPT_DIR"'/chicle.sh; chicle_choose A B C"
+    expect "❯"
+    send "\r"
+    expect eof
+  ' 2>&1 | clean_output | tail -1)
+  [[ "$output" == "A" ]] && pass "select first (enter)" || fail "select first (enter)" "A" "$output"
+
+  # Test: select second item (down + enter)
+  output=$(expect -c '
+    spawn bash -c "source '"$SCRIPT_DIR"'/chicle.sh; chicle_choose A B C"
+    expect "❯"
+    send "\033\[B\r"
+    expect eof
+  ' 2>&1 | clean_output | tail -1)
+  [[ "$output" == "B" ]] && pass "select second (down+enter)" || fail "select second (down+enter)" "B" "$output"
+
+  # Test: select third item (down + down + enter)
+  output=$(expect -c '
+    spawn bash -c "source '"$SCRIPT_DIR"'/chicle.sh; chicle_choose A B C"
+    expect "❯"
+    send "\033\[B\033\[B\r"
+    expect eof
+  ' 2>&1 | clean_output | tail -1)
+  [[ "$output" == "C" ]] && pass "select third (down+down+enter)" || fail "select third (down+down+enter)" "C" "$output"
+
+
+  echo "Testing chicle_choose --multi (expect)..."
+
+  # Test: multi-select first two items (space, down, space, enter)
+  output=$(expect -c '
+    spawn bash -c "source '"$SCRIPT_DIR"'/chicle.sh; chicle_choose --multi A B C"
+    expect "❯"
+    send " \033\[B \r"
+    expect eof
+  ' 2>&1 | clean_output | grep -E "^(A|B|C)$" | tr '\n' ',')
+  [[ "$output" == "A,B," ]] && pass "multi-select A,B" || fail "multi-select A,B" "A,B," "$output"
+
+
+  echo "Testing chicle_confirm (expect)..."
+
+  # Test: confirm yes
+  output=$(expect -c '
+    spawn bash -c "source '"$SCRIPT_DIR"'/chicle.sh; chicle_confirm \"Continue?\" && echo YES || echo NO"
+    expect "?"
+    send "y\r"
+    expect eof
+  ' 2>&1 | clean_output | tail -1)
+  [[ "$output" == "YES" ]] && pass "confirm y -> yes" || fail "confirm y -> yes" "YES" "$output"
+
+  # Test: confirm no
+  output=$(expect -c '
+    spawn bash -c "source '"$SCRIPT_DIR"'/chicle.sh; chicle_confirm \"Continue?\" && echo YES || echo NO"
+    expect "?"
+    send "n\r"
+    expect eof
+  ' 2>&1 | clean_output | tail -1)
+  [[ "$output" == "NO" ]] && pass "confirm n -> no" || fail "confirm n -> no" "NO" "$output"
+
+
+  echo "Testing chicle_input (expect)..."
+
+  # Test: basic input
+  output=$(expect -c '
+    spawn bash -c "source '"$SCRIPT_DIR"'/chicle.sh; chicle_input --prompt \"Name: \""
+    expect ":"
+    send "alice\r"
+    expect eof
+  ' 2>&1 | clean_output | tail -1)
+  [[ "$output" == "alice" ]] && pass "basic input" || fail "basic input" "alice" "$output"
+
+  # Test: password input (value captured even though not displayed)
+  output=$(expect -c '
+    spawn bash -c "source '"$SCRIPT_DIR"'/chicle.sh; chicle_input --password --prompt \"Pass: \""
+    expect ":"
+    send "secret\r"
+    expect eof
+  ' 2>&1 | clean_output | tail -1)
+  [[ "$output" == "secret" ]] && pass "password input" || fail "password input" "secret" "$output"
+
+else
+  echo "Skipping interactive tests (expect or perl not found)"
+fi
+
+
+# ============================================================================
+# Zsh interactive tests (expect)
+# ============================================================================
+
+if command -v expect &>/dev/null && command -v perl &>/dev/null && command -v zsh &>/dev/null; then
+  echo "Testing chicle_choose in zsh (expect)..."
+
+  # Test: select second item (down + enter) in zsh
+  output=$(expect -c '
+    spawn zsh -c "source '"$SCRIPT_DIR"'/chicle.sh; chicle_choose A B C"
+    expect "❯"
+    send "\033\[B\r"
+    expect eof
+  ' 2>&1 | clean_output | tail -1)
+  [[ "$output" == "B" ]] && pass "zsh: select second (down+enter)" || fail "zsh: select second (down+enter)" "B" "$output"
+
+
+  echo "Testing chicle_choose --multi in zsh (expect)..."
+
+  # Test: multi-select in zsh
+  output=$(expect -c '
+    spawn zsh -c "source '"$SCRIPT_DIR"'/chicle.sh; chicle_choose --multi A B C"
+    expect "❯"
+    send " \033\[B \r"
+    expect eof
+  ' 2>&1 | clean_output | grep -E "^(A|B|C)$" | tr '\n' ',')
+  [[ "$output" == "A,B," ]] && pass "zsh: multi-select A,B" || fail "zsh: multi-select A,B" "A,B," "$output"
+
+
+  echo "Testing chicle_input in zsh (expect)..."
+
+  # Test: password input in zsh
+  output=$(expect -c '
+    spawn zsh -c "source '"$SCRIPT_DIR"'/chicle.sh; chicle_input --password --prompt \"Pass: \""
+    expect ":"
+    send "secret\r"
+    expect eof
+  ' 2>&1 | clean_output | tail -1)
+  [[ "$output" == "secret" ]] && pass "zsh: password input" || fail "zsh: password input" "secret" "$output"
+
+else
+  echo "Skipping zsh tests (expect, perl, or zsh not found)"
+fi
+
+
+# ============================================================================
+# Summary
+# ============================================================================
+
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "Results: $PASS passed, $FAIL failed"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+[[ $FAIL -eq 0 ]] && exit 0 || exit 1


### PR DESCRIPTION
## Summary

- Adds `test.sh` with 20 tests covering all chicle functions
- Uses output capture for non-interactive tests (chicle_style, chicle_rule)
- Uses `expect` for interactive tests (chicle_choose, chicle_confirm, chicle_input)
- Includes cross-shell tests for both bash and zsh

## Test approach

After exploring various options (bats, pure output capture, expect), settled on:
1. **Output capture** for functions that just return formatted strings
2. **expect** for functions that need keyboard input simulation
3. **perl** for stripping ANSI escape codes from expect output

## Requirements

- `expect` (usually pre-installed on macOS/Linux)
- `perl` (usually pre-installed)
- `zsh` (for zsh-specific tests)

## Test plan

- [x] Run `./test.sh` and verify 20/20 pass
- [x] Test on bash
- [x] Test on zsh

🤖 Generated with [Claude Code](https://claude.com/claude-code)