### PR TITLE
Add styled logging (chicle_log)

### DIFF
--- a/chicle.sh
+++ b/chicle.sh
@@ -345,3 +345,27 @@ chicle_rule() {
   cols=$(tput cols)
   printf '%*s\n' "$cols" '' | tr ' ' "$char"
 }
+
+# Styled log output with icons
+# Usage: chicle_log --info|--success|--warn|--error|--debug|--step MESSAGE
+chicle_log() {
+  local level="" message=""
+  while [[ $# -gt 0 ]]; do
+    case $1 in
+      --info|--success|--warn|--error|--debug|--step)
+        level="${1#--}"; shift ;;
+      *)
+        message="$1"; shift ;;
+    esac
+  done
+
+  case $level in
+    info)    printf "%b%s%b %s\n" "$CHICLE_CYAN"   "ℹ" "$CHICLE_RESET" "$message" ;;
+    success) printf "%b%s%b %s\n" "$CHICLE_GREEN"  "✓" "$CHICLE_RESET" "$message" ;;
+    warn)    printf "%b%s%b %s\n" "$CHICLE_YELLOW" "⚠" "$CHICLE_RESET" "$message" ;;
+    error)   printf "%b%s%b %s\n" "$CHICLE_RED"    "✗" "$CHICLE_RESET" "$message" ;;
+    debug)   printf "%b%s %s%b\n" "$CHICLE_DIM"    "·" "$message" "$CHICLE_RESET" ;;
+    step)    printf "%b%s %s%b\n" "$CHICLE_BOLD"   "→" "$message" "$CHICLE_RESET" ;;
+    *)       printf "%s\n" "$message" ;;
+  esac
+}

--- a/test.sh
+++ b/test.sh
@@ -73,6 +73,27 @@ output=$(chicle_rule --char "=")
 [[ "$output" == *"="* ]] && pass "--char =" || fail "--char =" "=" "$output"
 
 
+echo "Testing chicle_log..."
+
+output=$(chicle_log --info "test")
+[[ "$output" == *"ℹ"*"test"* ]] && pass "--info" || fail "--info" "ℹ test" "$output"
+
+output=$(chicle_log --success "test")
+[[ "$output" == *"✓"*"test"* ]] && pass "--success" || fail "--success" "✓ test" "$output"
+
+output=$(chicle_log --warn "test")
+[[ "$output" == *"⚠"*"test"* ]] && pass "--warn" || fail "--warn" "⚠ test" "$output"
+
+output=$(chicle_log --error "test")
+[[ "$output" == *"✗"*"test"* ]] && pass "--error" || fail "--error" "✗ test" "$output"
+
+output=$(chicle_log --debug "test")
+[[ "$output" == *"·"*"test"* ]] && pass "--debug" || fail "--debug" "· test" "$output"
+
+output=$(chicle_log --step "test")
+[[ "$output" == *"→"*"test"* ]] && pass "--step" || fail "--step" "→ test" "$output"
+
+
 # ============================================================================
 # Interactive tests (expect)
 # ============================================================================


### PR DESCRIPTION
## Summary

- Adds `chicle_log` for consistent styled output with icons
- 6 log levels: info, success, warn, error, debug, step
- Includes 6 new tests (26 total now)

## Usage

```bash
chicle_log --info "Checking dependencies..."
chicle_log --success "All dependencies found"
chicle_log --warn "Optional package 'foo' not found"
chicle_log --error "Failed to download archive"
chicle_log --debug "Verbose debug info"
chicle_log --step "Installing packages"
```

## Test plan

- [x] Run `./test.sh` - 26/26 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)