### PR TITLE
Add step indicator (chicle_steps)

### DIFF
--- a/chicle.sh
+++ b/chicle.sh
@@ -369,3 +369,49 @@ chicle_log() {
     *)       printf "%s\n" "$message" ;;
   esac
 }
+
+# Step indicator for multi-step processes
+# Usage: chicle_steps --current N --total M [--title TEXT] [--style numeric|dots|progress]
+chicle_steps() {
+  local current=0 total=0 title="" style="numeric"
+  while [[ $# -gt 0 ]]; do
+    case $1 in
+      --current) current="$2"; shift 2 ;;
+      --total) total="$2"; shift 2 ;;
+      --title) title="$2"; shift 2 ;;
+      --style) style="$2"; shift 2 ;;
+      *) shift ;;
+    esac
+  done
+
+  [[ $total -eq 0 ]] && return 1
+
+  case $style in
+    numeric)
+      printf "%b[%d/%d]%b %s\n" "$CHICLE_BOLD" "$current" "$total" "$CHICLE_RESET" "$title"
+      ;;
+    dots)
+      local dots=""
+      for ((i=1; i<=total; i++)); do
+        if [[ $i -le $current ]]; then
+          dots+="●"
+        else
+          dots+="○"
+        fi
+        [[ $i -lt $total ]] && dots+=" "
+      done
+      printf "%b%s%b  %s\n" "$CHICLE_CYAN" "$dots" "$CHICLE_RESET" "$title"
+      ;;
+    progress)
+      local filled=$((current * 5 / total))
+      local empty=$((5 - filled))
+      local bar=""
+      for ((i=0; i<filled; i++)); do bar+="█"; done
+      for ((i=0; i<empty; i++)); do bar+="░"; done
+      printf "%b[%s]%b %s\n" "$CHICLE_CYAN" "$bar" "$CHICLE_RESET" "$title"
+      ;;
+    *)
+      printf "[%d/%d] %s\n" "$current" "$total" "$title"
+      ;;
+  esac
+}

--- a/test.sh
+++ b/test.sh
@@ -94,6 +94,21 @@ output=$(chicle_log --step "test")
 [[ "$output" == *"→"*"test"* ]] && pass "--step" || fail "--step" "→ test" "$output"
 
 
+echo "Testing chicle_steps..."
+
+output=$(chicle_steps --current 2 --total 5 --title "Installing")
+[[ "$output" == *"[2/5]"*"Installing"* ]] && pass "numeric style" || fail "numeric style" "[2/5] Installing" "$output"
+
+output=$(chicle_steps --current 2 --total 5 --title "Installing" --style dots)
+[[ "$output" == *"● ●"*"○"*"Installing"* ]] && pass "dots style" || fail "dots style" "● ● ○ Installing" "$output"
+
+output=$(chicle_steps --current 3 --total 5 --title "Installing" --style progress)
+[[ "$output" == *"███"*"░░"*"Installing"* ]] && pass "progress style" || fail "progress style" "[███░░] Installing" "$output"
+
+output=$(chicle_steps --current 5 --total 5 --title "Done" --style progress)
+[[ "$output" == *"█████"* ]] && pass "progress 100%" || fail "progress 100%" "[█████]" "$output"
+
+
 # ============================================================================
 # Interactive tests (expect)
 # ============================================================================


### PR DESCRIPTION
## Summary

- Adds `chicle_steps` for showing progress through multi-step processes
- 3 styles: numeric, dots, progress
- Includes 4 new tests (30 total)

## Usage

```bash
# Numeric (default)
chicle_steps --current 2 --total 5 --title "Installing"
# [2/5] Installing

# Dots
chicle_steps --current 2 --total 5 --title "Installing" --style dots
# ● ● ○ ○ ○  Installing

# Progress bar
chicle_steps --current 2 --total 5 --title "Installing" --style progress
# [██░░░] Installing
```

## Test plan

- [x] Run `./test.sh` - 30/30 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)