### PR TITLE
Add progress bar (chicle_progress)

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -109,6 +109,21 @@ output=$(chicle_steps --current 5 --total 5 --title "Done" --style progress)
 [[ "$output" == *"█████"* ]] && pass "progress 100%" || fail "progress 100%" "[█████]" "$output"
 
 
+echo "Testing chicle_progress..."
+
+output=$(chicle_progress --percent 50 --title "Test" --width 10)
+[[ "$output" == *"█████"*"░░░░░"* ]] && pass "--percent 50" || fail "--percent 50" "█████░░░░░" "$output"
+
+output=$(chicle_progress --percent 100 --title "Test" --width 10)
+[[ "$output" == *"██████████"*"100%"* ]] && pass "--percent 100" || fail "--percent 100" "██████████ 100%" "$output"
+
+output=$(chicle_progress --current 3 --total 10 --title "Test" --width 10)
+[[ "$output" == *"███"*"░░░░░░░"*"30%"* ]] && pass "--current/--total" || fail "--current/--total" "███░░░░░░░ 30%" "$output"
+
+output=$(chicle_progress --percent 0 --title "Test" --width 10)
+[[ "$output" == *"░░░░░░░░░░"*"0%"* ]] && pass "--percent 0" || fail "--percent 0" "░░░░░░░░░░ 0%" "$output"
+
+
 # ============================================================================
 # Interactive tests (expect)
 # ============================================================================


### PR DESCRIPTION
## Summary

- Adds `chicle_progress` for in-place updating progress bars
- Supports `--percent` or `--current`/`--total`
- Auto-calculates bar width based on terminal
- Turns green at 100%
- Includes 4 new tests (34 total)

## Usage

```bash
# Simple percentage
for i in 0 10 20 30 40 50 60 70 80 90 100; do
  chicle_progress --percent $i --title "Downloading"
  sleep 0.05
done
echo ''

# With item counts
chicle_progress --current 7 --total 10 --title "Processing"
```

## Demo

Updates in place - watch that bar fill up!

## Test plan

- [x] Run `./test.sh` - 34/34 pass
- [x] Test in zsh
- [x] Test in bash

🤖 Generated with [Claude Code](https://claude.com/claude-code)