### PR TITLE
Add ShellCheck linting, chicle_spin tests, and edge case coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,9 +4,23 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
 
 jobs:
+  shellcheck:
+    name: ShellCheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install ShellCheck
+        run: sudo apt-get update && sudo apt-get install -y shellcheck
+
+      - name: Lint chicle.sh
+        run: shellcheck chicle.sh
+
+      - name: Lint test.sh
+        run: shellcheck -x test.sh
+
   test:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,10 @@ Single file library (`chicle.sh`) that scripts can source. All functions are pre
 | `chicle_choose` | Interactive arrow-key menu picker |
 | `chicle_spin` | Spinner animation while command runs |
 | `chicle_rule` | Print horizontal line |
+| `chicle_log` | Styled log output with icons |
+| `chicle_steps` | Step indicator for multi-step processes |
+| `chicle_table` | Formatted table output |
+| `chicle_progress` | Progress bar with in-place updating |
 
 ### Terminal Control
 
@@ -27,13 +31,21 @@ Single file library (`chicle.sh`) that scripts can source. All functions are pre
 
 ## Testing
 
-Manual testing - source the library and try each function:
+Run the automated test suite:
 
 ```bash
-source chicle.sh
-chicle_style --bold --cyan "Test"
-chicle_confirm "Works?"
-chicle_choose "A" "B" "C"
+bash test.sh
+```
+
+Tests require `TERM` to be set (CI uses `TERM=xterm`). Interactive tests (chicle_choose, chicle_confirm, chicle_input) require `expect` and `perl`. Zsh compatibility tests additionally require `zsh`.
+
+## Linting
+
+ShellCheck is used for static analysis:
+
+```bash
+shellcheck chicle.sh
+shellcheck -x test.sh
 ```
 
 ## Compatibility

--- a/chicle.sh
+++ b/chicle.sh
@@ -22,9 +22,9 @@ _chicle_read_char() {
 _chicle_read_chars() {
   local count="$1" var="$2"
   if [[ -n "$ZSH_VERSION" ]]; then
-    read -rsk"$count" "$var"
+    read -rsk"$count" "${var?}"
   else
-    read -rsn"$count" "$var"
+    read -rsn"$count" "${var?}"
   fi
 }
 
@@ -200,7 +200,8 @@ chicle_spin() {
 
     # Small delay to ensure exit code is written
     sleep 0.05
-    local exit_code=$(cat "$tmpfile" 2>/dev/null || echo 1)
+    local exit_code
+    exit_code=$(cat "$tmpfile" 2>/dev/null || echo 1)
     rm -f "$tmpfile"
   fi
 
@@ -210,7 +211,7 @@ chicle_spin() {
     printf "\r%b✗%b %s\n" "$CHICLE_RED" "$CHICLE_RESET" "$title"
   fi
 
-  return $exit_code
+  return "$exit_code"
 }
 
 # Interactive chooser with arrow keys
@@ -248,21 +249,23 @@ chicle_choose() {
     if [[ -n "$ZSH_VERSION" ]]; then
       echo $(($1 + 1))
     else
-      echo $1
+      echo "$1"
     fi
   }
 
   _is_selected() {
-    local idx=$(_sel_idx $1)
-    [[ -n "${selections[$idx]}" ]]
+    local idx
+    idx=$(_sel_idx "$1")
+    [[ -n "${selections[idx]}" ]]
   }
 
   _toggle_selection() {
-    local idx=$(_sel_idx $1)
-    if [[ -n "${selections[$idx]}" ]]; then
-      selections[$idx]=""
+    local idx
+    idx=$(_sel_idx "$1")
+    if [[ -n "${selections[idx]}" ]]; then
+      selections[idx]=""
     else
-      selections[$idx]=1
+      selections[idx]=1
     fi
   }
 
@@ -296,6 +299,7 @@ chicle_choose() {
 
   draw_menu
 
+  local key=""
   while true; do
     _chicle_read_char key
 
@@ -412,7 +416,8 @@ chicle_steps() {
     progress)
       local filled=$((current * 5 / total))
       local empty=$((5 - filled))
-      local bar="$(_chicle_repeat "█" "$filled")$(_chicle_repeat "░" "$empty")"
+      local bar
+      bar="$(_chicle_repeat "█" "$filled")$(_chicle_repeat "░" "$empty")"
       printf "%b[%s]%b %s\n" "$CHICLE_CYAN" "$bar" "$CHICLE_RESET" "$title"
       ;;
     *)
@@ -468,7 +473,7 @@ chicle_table() {
     _chicle_split "$header" "$sep"
     ncols=${#_fields[@]}
     for ((c=0; c<ncols; c++)); do
-      widths[$c]=${#_fields[$c]}
+      widths[c]=${#_fields[c]}
     done
     all_rows+=("H:$header")
   fi
@@ -481,12 +486,12 @@ chicle_table() {
       ncols=$rc
       # Extend widths array
       for ((c=${#widths[@]}; c<ncols; c++)); do
-        widths[$c]=0
+        widths[c]=0
       done
     fi
     for ((c=0; c<rc; c++)); do
-      local len=${#_fields[$c]}
-      [[ $len -gt ${widths[$c]:-0} ]] && widths[$c]=$len
+      local len=${#_fields[c]}
+      [[ $len -gt ${widths[c]:-0} ]] && widths[c]=$len
     done
     all_rows+=("D:$row")
   done
@@ -498,7 +503,7 @@ chicle_table() {
     local left="$1" mid="$2" right="$3" fill="$4"
     printf "%s" "$left"
     for ((c=0; c<ncols; c++)); do
-      _chicle_repeat "$fill" $((widths[$c] + 2))
+      _chicle_repeat "$fill" $((widths[c] + 2))
       [[ $c -lt $((ncols - 1)) ]] && printf "%s" "$mid"
     done
     printf "%s\n" "$right"
@@ -611,7 +616,8 @@ chicle_progress() {
 
   local filled=$((percent * width / 100))
   local empty=$((width - filled))
-  local bar="$(_chicle_repeat "█" "$filled")$(_chicle_repeat "░" "$empty")"
+  local bar
+  bar="$(_chicle_repeat "█" "$filled")$(_chicle_repeat "░" "$empty")"
 
   local color="$CHICLE_CYAN"
   [[ $percent -eq 100 ]] && color="$CHICLE_GREEN"

--- a/test.sh
+++ b/test.sh
@@ -2,6 +2,9 @@
 # chicle test suite
 # Requires: expect (for interactive tests)
 
+# shellcheck disable=SC2015  # A && B || C pattern is intentional for test assertions
+# shellcheck source=chicle.sh
+
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -124,6 +127,38 @@ output=$(chicle_progress --percent 0 --title "Test" --width 10)
 [[ "$output" == *"░░░░░░░░░░"*"0%"* ]] && pass "--percent 0" || fail "--percent 0" "░░░░░░░░░░ 0%" "$output"
 
 
+echo "Testing chicle_spin..."
+
+# Test: successful command shows checkmark
+output=$(chicle_spin --title "Working" -- true 2>&1)
+[[ "$output" == *"✓"*"Working"* ]] && pass "success shows ✓" || fail "success shows ✓" "✓ Working" "$output"
+
+# Test: successful command returns 0
+if chicle_spin --title "OK" -- true >/dev/null 2>&1; then
+  pass "success returns 0"
+else
+  fail "success returns 0" "0" "non-zero"
+fi
+
+# Test: failed command shows ✗
+output=$(chicle_spin --title "Failing" -- false 2>&1 || true)
+[[ "$output" == *"✗"*"Failing"* ]] && pass "failure shows ✗" || fail "failure shows ✗" "✗ Failing" "$output"
+
+# Test: failed command returns non-zero
+exit_code=0
+chicle_spin --title "Fail" -- false >/dev/null 2>&1 || exit_code=$?
+[[ $exit_code -ne 0 ]] && pass "failure returns non-zero" || fail "failure returns non-zero" "non-zero" "0"
+
+# Test: spin without title
+output=$(chicle_spin -- true 2>&1)
+[[ "$output" == *"✓"* ]] && pass "no title" || fail "no title" "✓" "$output"
+
+# Test: preserves command exit code
+exit_code=0
+chicle_spin -- bash -c "exit 42" >/dev/null 2>&1 || exit_code=$?
+[[ "$exit_code" -eq 42 ]] && pass "preserves exit code 42" || fail "preserves exit code 42" "42" "$exit_code"
+
+
 echo "Testing chicle_table..."
 
 # Test: basic table with header (box style)
@@ -175,6 +210,75 @@ output=$(chicle_table --header "A,B,C" "1,2")
 # Test: header-only table (no data rows)
 output=$(chicle_table --header "Name,Value")
 [[ "$output" == *"Name"* && "$output" == *"┌"* && "$output" == *"┘"* ]] && pass "header-only table" || fail "header-only table" "Name with borders" "$output"
+
+
+# ============================================================================
+# Edge case tests
+# ============================================================================
+
+echo "Testing edge cases..."
+
+# chicle_style: empty text
+output=$(chicle_style --bold "")
+expected=$'\033[1m\033[0m'
+[[ "$output" == "$expected" ]] && pass "style: empty text" || fail "style: empty text" "$expected" "$output"
+
+# chicle_style: text only (no flags)
+output=$(chicle_style "plain")
+expected=$'plain\033[0m'
+[[ "$output" == "$expected" ]] && pass "style: text only" || fail "style: text only" "$expected" "$output"
+
+# chicle_style: all formatting combined
+output=$(chicle_style --bold --dim --red "alert")
+[[ "$output" == *$'\033[1m'*$'\033[2m'*$'\033[31m'*"alert"* ]] && pass "style: bold+dim+red" || fail "style: bold+dim+red" "combined formatting" "$output"
+
+# chicle_log: no level defaults to plain
+output=$(chicle_log "just text")
+[[ "$output" == "just text" ]] && pass "log: no level" || fail "log: no level" "just text" "$output"
+
+# chicle_steps: total 0 returns error
+if chicle_steps --current 1 --total 0 2>/dev/null; then
+  fail "steps: total 0 returns error" "non-zero exit" "0"
+else
+  pass "steps: total 0 returns error"
+fi
+
+# chicle_steps: step 1 of 1
+output=$(chicle_steps --current 1 --total 1 --title "Only step")
+[[ "$output" == *"[1/1]"*"Only step"* ]] && pass "steps: 1 of 1" || fail "steps: 1 of 1" "[1/1] Only step" "$output"
+
+# chicle_progress: percent clamped above 100
+output=$(chicle_progress --percent 150 --width 10)
+[[ "$output" == *"100%"* ]] && pass "progress: clamp >100" || fail "progress: clamp >100" "100%" "$output"
+
+# chicle_progress: negative percent clamped to 0
+output=$(chicle_progress --percent -10 --width 10)
+[[ "$output" == *"0%"* ]] && pass "progress: clamp <0" || fail "progress: clamp <0" "0%" "$output"
+
+# chicle_choose: no options returns error
+# shellcheck disable=SC2119  # intentionally calling with no args to test error case
+if chicle_choose 2>/dev/null; then
+  fail "choose: no options returns error" "non-zero exit" "0"
+else
+  pass "choose: no options returns error"
+fi
+
+# chicle_table: single column
+output=$(chicle_table --header "Name" "alice" "bob")
+[[ "$output" == *"alice"* && "$output" == *"bob"* ]] && pass "table: single column" || fail "table: single column" "alice bob" "$output"
+
+# chicle_rule: default char is ─
+output=$(chicle_rule)
+# Should only contain ─ and newline
+cleaned=$(echo "$output" | tr -d '─' | tr -d '\n')
+[[ -z "$cleaned" ]] && pass "rule: default only ─" || fail "rule: default only ─" "only ─ chars" "$cleaned"
+
+# chicle_steps: dots style at boundaries (0 of N and N of N)
+output=$(chicle_steps --current 0 --total 3 --style dots)
+[[ "$output" == *"○ ○ ○"* ]] && pass "steps: dots 0/3" || fail "steps: dots 0/3" "○ ○ ○" "$output"
+
+output=$(chicle_steps --current 3 --total 3 --style dots)
+[[ "$output" == *"● ● ●"* ]] && pass "steps: dots 3/3" || fail "steps: dots 3/3" "● ● ●" "$output"
 
 
 # ============================================================================


### PR DESCRIPTION
- Fix all ShellCheck warnings in chicle.sh (SC2155, SC2229, SC2086, SC2004,
  SC2154) and add directives for intentional patterns in test.sh
- Add ShellCheck job to CI workflow, trigger PRs against all branches
- Add 6 tests for chicle_spin (success/failure output, exit codes, no title)
- Add 13 edge case tests (empty text, clamping, boundary values, error cases)
- Update CLAUDE.md: document all 10 functions, replace manual testing section
  with automated test suite and linting instructions

https://claude.ai/code/session_01KHfuJbawB7rBLZVxv7povZ