### PR TITLE
Fix zsh ctrl-c handling, add test:zsh task

### DIFF
--- a/.mise/tasks/test/zsh
+++ b/.mise/tasks/test/zsh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+#MISE description="Run zsh-specific BATS tests"
+
+set -e
+
+if ! command -v zsh &>/dev/null; then
+  echo "zsh not found, skipping"
+  exit 0
+fi
+
+bats --filter "zsh" test/bash/

--- a/chicle.sh
+++ b/chicle.sh
@@ -339,15 +339,20 @@ chicle_choose() {
   local key=""
   while true; do
     # Read a keypress, with timeout so ctrl-c interrupt flag is checked.
-    # bash's read restarts after signal traps (SA_RESTART), so without a
-    # timeout, ctrl-c sets the flag but read blocks until the next keypress.
+    # Both bash and zsh restart read after signal traps (SA_RESTART), so
+    # without a timeout, ctrl-c sets the flag but read blocks until the
+    # next keypress. Polling with read -t lets us check the flag.
     key=""
     if [[ -n "$ZSH_VERSION" ]]; then
-      read -rsk1 key </dev/tty
+      while [[ -z "$_chicle_interrupted" ]]; do
+        if read -rsk1 -t "$_chicle_read_timeout" key </dev/tty; then
+          break  # zsh: 0 = got input, 1 = timeout
+        fi
+      done
     else
       while [[ -z "$_chicle_interrupted" ]]; do
         IFS= read -rsn1 -t "$_chicle_read_timeout" key </dev/tty
-        [[ $? -le 128 ]] && break  # got input (not a timeout)
+        [[ $? -le 128 ]] && break  # bash: 0 = got input, >128 = timeout
       done
     fi
     [[ -n "$_chicle_interrupted" ]] && break

--- a/test/bash/chicle.bats
+++ b/test/bash/chicle.bats
@@ -454,6 +454,18 @@ expect_available() {
 # ctrl-c tests (expect)
 # ============================================================================
 
+@test "choose: menu waits for input (no auto-select on timeout)" {
+  if ! expect_available; then skip "expect or perl not found"; fi
+  output=$(expect -c '
+    spawn bash -c "source '"$BATS_TEST_DIRNAME"'/../../chicle.sh; chicle_choose A B C"
+    expect "❯"
+    sleep 0.5
+    send "\033\[B\r"
+    expect eof
+  ' 2>&1 | clean_output | tail -1)
+  [ "$output" = "B" ]
+}
+
 @test "choose: ctrl-c returns 130" {
   if ! expect_available; then skip "expect or perl not found"; fi
   expect -c '
@@ -540,4 +552,39 @@ zsh_expect_available() {
     expect eof
   ' 2>&1 | clean_output | tail -1)
   [ "$output" = "secret" ]
+}
+
+@test "zsh: menu waits for input (no auto-select on timeout)" {
+  if ! zsh_expect_available; then skip "expect, perl, or zsh not found"; fi
+  output=$(expect -c '
+    spawn zsh -c "source '"$BATS_TEST_DIRNAME"'/../../chicle.sh; chicle_choose A B C"
+    expect "❯"
+    sleep 0.5
+    send "\033\[B\r"
+    expect eof
+  ' 2>&1 | clean_output | tail -1)
+  [ "$output" = "B" ]
+}
+
+@test "zsh: ctrl-c returns 130" {
+  if ! zsh_expect_available; then skip "expect, perl, or zsh not found"; fi
+  expect -c '
+    spawn zsh -c "source '"$BATS_TEST_DIRNAME"'/../../chicle.sh; chicle_choose A B C; echo EXIT:\$?"
+    expect "❯"
+    send "\x03"
+    expect "EXIT:"
+    expect eof
+  ' 2>&1 | clean_output | grep -q "EXIT:130"
+}
+
+@test "zsh: --var ctrl-c does not kill parent" {
+  if ! zsh_expect_available; then skip "expect, perl, or zsh not found"; fi
+  output=$(expect -c '
+    spawn zsh -c "source '"$BATS_TEST_DIRNAME"'/../../chicle.sh; chicle_choose --var RESULT A B C; echo SURVIVED:\$?"
+    expect "❯"
+    send "\x03"
+    expect "SURVIVED:"
+    expect eof
+  ' 2>&1 | clean_output | grep "^SURVIVED:")
+  [ "$output" = "SURVIVED:130" ]
 }

--- a/test/bash/repro-sigint-zsh.sh
+++ b/test/bash/repro-sigint-zsh.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env zsh
+# Test whether zsh's read -k1 has the SA_RESTART issue
+# See: https://github.com/KnickKnackLabs/chicle/issues/27
+
+interrupted=""
+trap 'interrupted=1' INT
+
+stty -echo -icanon </dev/tty
+
+echo "Press ctrl-c..." >/dev/tty
+while true; do
+  read -rsk1 key </dev/tty
+  if [[ -n "$interrupted" ]]; then
+    echo "[interrupted]" >/dev/tty
+    break
+  fi
+  echo "[key: ${(q)key}]" >/dev/tty
+done
+
+stty echo icanon </dev/tty
+echo "exited cleanly" >/dev/tty


### PR DESCRIPTION
## Summary

Addresses x1f9's review note from #28 — zsh has the same SA_RESTART behavior as bash.

- **zsh timeout polling**: Applied the same `read -t 0.05` polling fix to the zsh code path. Without this, ctrl-c in zsh required an extra keypress.
- **zsh timeout exit code**: zsh returns exit code 1 on timeout (not >128 like bash). The previous check (`$? -le 128`) treated timeouts as input, causing immediate auto-selection without user interaction.
- **`test:zsh` task**: `mise run test:zsh` runs zsh-specific tests via BATS `--filter`.
- **Idle timeout tests**: New tests for both bash and zsh that wait 500ms before sending input — catches the auto-select-on-timeout class of bug.

## Test plan

- [x] 71/71 BATS tests pass (bash + zsh)
- [x] ShellCheck clean
- [x] `mise run test:zsh` — 6/6 pass
- [x] Manual: `zsh -c 'source chicle.sh; chicle_choose A B C'` waits for input
- [x] Manual: ctrl-c in zsh exits within ~50ms

🤖 Generated with [Claude Code](https://claude.com/claude-code)