### PR TITLE
Add chicle_file / Chicle-File interactive file picker

### DIFF
--- a/chicle.psm1
+++ b/chicle.psm1
@@ -641,6 +641,95 @@ function Chicle-Progress {
     Write-Host -NoNewline $formatted
 }
 
+function Chicle-File {
+    <#
+    .SYNOPSIS
+    Interactive file picker with directory navigation.
+    .EXAMPLE
+    $file = Chicle-File -Filter "*.json" -Path "/etc"
+    .EXAMPLE
+    $dir = Chicle-File -Dir -Header "Choose install directory"
+    #>
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [string]$Header = "",
+        [switch]$Dir,
+        [string]$Filter = "",
+        [string]$Path = "."
+    )
+
+    $currentDir = (Resolve-Path $Path).Path
+
+    while ($true) {
+        $entries = [System.Collections.Generic.List[string]]::new()
+
+        # .. to go up (unless at filesystem root)
+        $root = [System.IO.Path]::GetPathRoot($currentDir)
+        if ($currentDir -ne $root) {
+            $entries.Add("..")
+        }
+
+        # . to select current directory (Dir mode only)
+        if ($Dir) {
+            $entries.Add(".")
+        }
+
+        # Subdirectories (alphabetical, skip hidden)
+        $dirs = Get-ChildItem -Path $currentDir -Directory -ErrorAction SilentlyContinue |
+            Where-Object { -not $_.Name.StartsWith(".") } |
+            Sort-Object Name
+        foreach ($d in $dirs) {
+            $entries.Add("$($d.Name)/")
+        }
+
+        # Files (alphabetical, skip hidden, apply filter unless Dir mode)
+        if (-not $Dir) {
+            $fileParams = @{
+                Path = $currentDir
+                File = $true
+                ErrorAction = 'SilentlyContinue'
+            }
+            if ($Filter) { $fileParams['Filter'] = $Filter }
+            $files = Get-ChildItem @fileParams |
+                Where-Object { -not $_.Name.StartsWith(".") } |
+                Sort-Object Name
+            foreach ($f in $files) {
+                $entries.Add($f.Name)
+            }
+        }
+
+        # Nothing to show
+        if ($entries.Count -eq 0) { return $null }
+
+        # Header: optional user text + current path
+        $displayHeader = if ($Header) { "$Header $([char]0x2014) $currentDir" } else { $currentDir }
+
+        $selection = Chicle-Choose -Header $displayHeader -Options $entries.ToArray()
+
+        # Quit or interrupt
+        if ($null -eq $selection) { return $null }
+
+        switch -Exact ($selection) {
+            ".." {
+                $currentDir = Split-Path $currentDir -Parent
+            }
+            "." {
+                return $currentDir
+            }
+            default {
+                if ($selection.EndsWith("/")) {
+                    # Directory: descend
+                    $currentDir = Join-Path $currentDir $selection.TrimEnd("/")
+                } else {
+                    # File: select
+                    return (Join-Path $currentDir $selection)
+                }
+            }
+        }
+    }
+}
+
 Export-ModuleMember -Function @(
     'Chicle-Style',
     'Chicle-Input',
@@ -651,5 +740,6 @@ Export-ModuleMember -Function @(
     'Chicle-Log',
     'Chicle-Steps',
     'Chicle-Table',
-    'Chicle-Progress'
+    'Chicle-Progress',
+    'Chicle-File'
 )

--- a/chicle.psm1
+++ b/chicle.psm1
@@ -645,6 +645,10 @@ function Chicle-File {
     <#
     .SYNOPSIS
     Interactive file picker with directory navigation.
+    .DESCRIPTION
+    The -Filter argument applies to files only; directories are always shown
+    so the user can navigate freely. -Filter is case-insensitive on Windows
+    and case-sensitive on macOS/Linux (PowerShell native -Filter behaviour).
     .EXAMPLE
     $file = Chicle-File -Filter "*.json" -Path "/etc"
     .EXAMPLE

--- a/chicle.sh
+++ b/chicle.sh
@@ -695,21 +695,37 @@ chicle_progress() {
 
 # Interactive file picker
 # Usage: chicle_file [--header TEXT] [--dir] [--filter GLOB] [--path DIR] [--var VARNAME]
+#
+# --filter applies to files only; directories are always shown so the user
+# can navigate freely. Globbing is case-sensitive (bash default).
 chicle_file() {
   local header="" dir_only="" filter="" dir="" _chicle_var=""
   while [[ $# -gt 0 ]]; do
     case $1 in
-      --header) header="$2"; shift 2 ;;
+      --header)
+        [[ $# -ge 2 ]] || { echo "chicle_file: --header requires a value" >&2; return 2; }
+        header="$2"; shift 2 ;;
       --dir) dir_only=1; shift ;;
-      --filter) filter="$2"; shift 2 ;;
-      --path) dir="$2"; shift 2 ;;
-      --var) _chicle_var="$2"; shift 2 ;;
-      *) shift ;;
+      --filter)
+        [[ $# -ge 2 ]] || { echo "chicle_file: --filter requires a value" >&2; return 2; }
+        filter="$2"; shift 2 ;;
+      --path)
+        [[ $# -ge 2 ]] || { echo "chicle_file: --path requires a value" >&2; return 2; }
+        dir="$2"; shift 2 ;;
+      --var)
+        [[ $# -ge 2 ]] || { echo "chicle_file: --var requires a value" >&2; return 2; }
+        _chicle_var="$2"; shift 2 ;;
+      *) echo "chicle_file: unknown argument: $1" >&2; return 2 ;;
     esac
   done
 
   # Default to current directory, resolve to absolute path
-  dir="$(cd "${dir:-.}" && pwd)" || return 1
+  local _path_input="${dir:-.}"
+  if [[ ! -d "$_path_input" ]]; then
+    echo "chicle_file: no such directory: $_path_input" >&2
+    return 1
+  fi
+  dir="$(cd "$_path_input" && pwd)"
 
   while true; do
     local entries=() entry

--- a/chicle.sh
+++ b/chicle.sh
@@ -692,3 +692,93 @@ chicle_progress() {
   # Print with \r to update in place (no newline)
   printf "\r%s %b[%s]%b %3d%%" "$title" "$color" "$bar" "$CHICLE_RESET" "$percent"
 }
+
+# Interactive file picker
+# Usage: chicle_file [--header TEXT] [--dir] [--filter GLOB] [--path DIR] [--var VARNAME]
+chicle_file() {
+  local header="" dir_only="" filter="" dir="" _chicle_var=""
+  while [[ $# -gt 0 ]]; do
+    case $1 in
+      --header) header="$2"; shift 2 ;;
+      --dir) dir_only=1; shift ;;
+      --filter) filter="$2"; shift 2 ;;
+      --path) dir="$2"; shift 2 ;;
+      --var) _chicle_var="$2"; shift 2 ;;
+      *) shift ;;
+    esac
+  done
+
+  # Default to current directory, resolve to absolute path
+  dir="$(cd "${dir:-.}" && pwd)" || return 1
+
+  while true; do
+    local entries=() entry
+
+    # .. to go up (unless at filesystem root)
+    [[ "$dir" != "/" ]] && entries+=("..")
+
+    # . to select current directory (--dir mode only)
+    [[ -n "$dir_only" ]] && entries+=(".")
+
+    # Subdirectories (alphabetical, skip hidden)
+    for entry in "$dir"/*/; do
+      [[ -d "$entry" ]] && entries+=("$(basename "$entry")/")
+    done
+
+    # Files (alphabetical, skip hidden, apply filter unless --dir)
+    if [[ -z "$dir_only" ]]; then
+      if [[ -n "$filter" ]]; then
+        # shellcheck disable=SC2086
+        for entry in "$dir"/$filter; do
+          [[ -f "$entry" ]] && entries+=("$(basename "$entry")")
+        done
+      else
+        for entry in "$dir"/*; do
+          [[ -f "$entry" ]] && entries+=("$(basename "$entry")")
+        done
+      fi
+    fi
+
+    # Nothing to show (empty root directory)
+    [[ ${#entries[@]} -eq 0 ]] && return 1
+
+    # Header: optional user text + current path
+    local display_header
+    if [[ -n "$header" ]]; then
+      display_header="$header — $dir"
+    else
+      display_header="$dir"
+    fi
+
+    local _chicle_selection=""
+    chicle_choose --header "$display_header" --var _chicle_selection "${entries[@]}"
+    local rc=$?
+    [[ $rc -ne 0 ]] && return $rc
+
+    case "$_chicle_selection" in
+      "..")
+        dir="$(dirname "$dir")"
+        ;;
+      ".")
+        if [[ -n "$_chicle_var" ]]; then
+          printf -v "$_chicle_var" '%s' "$dir"
+        else
+          echo "$dir"
+        fi
+        return 0
+        ;;
+      */)
+        dir="$dir/${_chicle_selection%/}"
+        ;;
+      *)
+        local _chicle_result="$dir/$_chicle_selection"
+        if [[ -n "$_chicle_var" ]]; then
+          printf -v "$_chicle_var" '%s' "$_chicle_result"
+        else
+          echo "$_chicle_result"
+        fi
+        return 0
+        ;;
+    esac
+  done
+}

--- a/test/bash/chicle.bats
+++ b/test/bash/chicle.bats
@@ -588,3 +588,185 @@ zsh_expect_available() {
   ' 2>&1 | clean_output | grep "^SURVIVED:")
   [ "$output" = "SURVIVED:130" ]
 }
+
+# ============================================================================
+# chicle_file — interactive file picker tests (expect)
+# ============================================================================
+
+_setup_file_tree() {
+  local root="$BATS_TMPDIR/chicle_file_$$_$RANDOM"
+  rm -rf "$root"
+  mkdir -p "$root/alpha/nested" "$root/beta"
+  echo "x" > "$root/file1.txt"
+  echo "x" > "$root/file2.sh"
+  echo "x" > "$root/alpha/inner.txt"
+  echo "x" > "$root/alpha/nested/deep.txt"
+  echo "$root"
+}
+
+@test "file: select a file" {
+  if ! expect_available; then skip "expect or perl not found"; fi
+  local root
+  root=$(_setup_file_tree)
+  # Menu: .., alpha/, beta/, file1.txt, file2.sh
+  # down 3x → file1.txt, enter
+  output=$(expect -c '
+    spawn bash -c "source '"$BATS_TEST_DIRNAME"'/../../chicle.sh; chicle_file --path '"$root"'"
+    expect "❯"
+    send "\033\[B\033\[B\033\[B\r"
+    expect eof
+  ' 2>&1 | clean_output | tail -1)
+  [ "$output" = "$root/file1.txt" ]
+  rm -rf "$root"
+}
+
+@test "file: navigate into directory and select" {
+  if ! expect_available; then skip "expect or perl not found"; fi
+  local root
+  root=$(_setup_file_tree)
+  # Menu: .., alpha/, beta/, file1.txt, file2.sh
+  # down 1x → alpha/, enter
+  # New menu: .., nested/, inner.txt
+  # down 2x → inner.txt, enter
+  output=$(expect -c '
+    spawn bash -c "source '"$BATS_TEST_DIRNAME"'/../../chicle.sh; chicle_file --path '"$root"'"
+    expect "❯"
+    send "\033\[B\r"
+    expect "❯"
+    send "\033\[B\033\[B\r"
+    expect eof
+  ' 2>&1 | clean_output | tail -1)
+  [ "$output" = "$root/alpha/inner.txt" ]
+  rm -rf "$root"
+}
+
+@test "file: navigate up with .." {
+  if ! expect_available; then skip "expect or perl not found"; fi
+  local root
+  root=$(_setup_file_tree)
+  # Start in alpha: .., nested/, inner.txt
+  # enter on .. (cursor starts there) → back to root
+  # Menu: .., alpha/, beta/, file1.txt, file2.sh
+  # down 3x → file1.txt, enter
+  output=$(expect -c '
+    spawn bash -c "source '"$BATS_TEST_DIRNAME"'/../../chicle.sh; chicle_file --path '"$root/alpha"'"
+    expect "❯"
+    send "\r"
+    expect "❯"
+    send "\033\[B\033\[B\033\[B\r"
+    expect eof
+  ' 2>&1 | clean_output | tail -1)
+  [ "$output" = "$root/file1.txt" ]
+  rm -rf "$root"
+}
+
+@test "file: q returns exit code 1" {
+  if ! expect_available; then skip "expect or perl not found"; fi
+  local root
+  root=$(_setup_file_tree)
+  expect -c '
+    spawn bash -c "source '"$BATS_TEST_DIRNAME"'/../../chicle.sh; chicle_file --path '"$root"'; echo EXIT:\$?"
+    expect "❯"
+    send "q"
+    expect "EXIT:"
+    expect eof
+  ' 2>&1 | clean_output | grep -q "EXIT:1"
+  rm -rf "$root"
+}
+
+@test "file: ctrl-c returns exit code 130" {
+  if ! expect_available; then skip "expect or perl not found"; fi
+  local root
+  root=$(_setup_file_tree)
+  expect -c '
+    spawn bash -c "source '"$BATS_TEST_DIRNAME"'/../../chicle.sh; chicle_file --path '"$root"'; echo EXIT:\$?"
+    expect "❯"
+    send "\x03"
+    expect "EXIT:"
+    expect eof
+  ' 2>&1 | clean_output | grep -q "EXIT:130"
+  rm -rf "$root"
+}
+
+@test "file: --filter shows only matching files" {
+  if ! expect_available; then skip "expect or perl not found"; fi
+  local root
+  root=$(_setup_file_tree)
+  # Menu with --filter *.txt: .., alpha/, beta/, file1.txt
+  # (file2.sh is filtered out)
+  # down 3x → file1.txt, enter
+  output=$(expect -c '
+    spawn bash -c "source '"$BATS_TEST_DIRNAME"'/../../chicle.sh; chicle_file --path '"$root"' --filter \"*.txt\""
+    expect "❯"
+    send "\033\[B\033\[B\033\[B\r"
+    expect eof
+  ' 2>&1 | clean_output | tail -1)
+  [ "$output" = "$root/file1.txt" ]
+  rm -rf "$root"
+}
+
+@test "file: --dir mode select current directory" {
+  if ! expect_available; then skip "expect or perl not found"; fi
+  local root
+  root=$(_setup_file_tree)
+  # Menu: .., ., alpha/, beta/
+  # down 1x → ., enter
+  output=$(expect -c '
+    spawn bash -c "source '"$BATS_TEST_DIRNAME"'/../../chicle.sh; chicle_file --dir --path '"$root"'"
+    expect "❯"
+    send "\033\[B\r"
+    expect eof
+  ' 2>&1 | clean_output | tail -1)
+  [ "$output" = "$root" ]
+  rm -rf "$root"
+}
+
+@test "file: --dir mode navigate and select" {
+  if ! expect_available; then skip "expect or perl not found"; fi
+  local root
+  root=$(_setup_file_tree)
+  # Menu: .., ., alpha/, beta/
+  # down 2x → alpha/, enter (descend)
+  # New menu: .., ., nested/
+  # down 1x → ., enter (select alpha)
+  output=$(expect -c '
+    spawn bash -c "source '"$BATS_TEST_DIRNAME"'/../../chicle.sh; chicle_file --dir --path '"$root"'"
+    expect "❯"
+    send "\033\[B\033\[B\r"
+    expect "❯"
+    send "\033\[B\r"
+    expect eof
+  ' 2>&1 | clean_output | tail -1)
+  [ "$output" = "$root/alpha" ]
+  rm -rf "$root"
+}
+
+@test "file: --header shown in display" {
+  if ! expect_available; then skip "expect or perl not found"; fi
+  local root
+  root=$(_setup_file_tree)
+  # Verify header appears, then select file1.txt
+  output=$(expect -c '
+    spawn bash -c "source '"$BATS_TEST_DIRNAME"'/../../chicle.sh; chicle_file --header \"Pick\" --path '"$root"'"
+    expect "Pick"
+    send "\033\[B\033\[B\033\[B\r"
+    expect eof
+  ' 2>&1 | clean_output | tail -1)
+  [ "$output" = "$root/file1.txt" ]
+  rm -rf "$root"
+}
+
+@test "file: --var sets variable" {
+  if ! expect_available; then skip "expect or perl not found"; fi
+  local root
+  root=$(_setup_file_tree)
+  output=$(expect -c '
+    spawn bash -c "source '"$BATS_TEST_DIRNAME"'/../../chicle.sh; chicle_file --var RESULT --path '"$root"'; echo RESULT:\$RESULT"
+    expect "❯"
+    send "\033\[B\033\[B\033\[B\r"
+    expect "RESULT:"
+    expect eof
+  ' 2>&1 | clean_output | grep "^RESULT:")
+  [ "$output" = "RESULT:$root/file1.txt" ]
+  rm -rf "$root"
+}

--- a/test/bash/chicle.bats
+++ b/test/bash/chicle.bats
@@ -594,8 +594,8 @@ zsh_expect_available() {
 # ============================================================================
 
 _setup_file_tree() {
-  local root="$BATS_TMPDIR/chicle_file_$$_$RANDOM"
-  rm -rf "$root"
+  # Use $BATS_TEST_TMPDIR so BATS auto-cleans after each test
+  local root="$BATS_TEST_TMPDIR/chicle_file"
   mkdir -p "$root/alpha/nested" "$root/beta"
   echo "x" > "$root/file1.txt"
   echo "x" > "$root/file2.sh"
@@ -617,7 +617,6 @@ _setup_file_tree() {
     expect eof
   ' 2>&1 | clean_output | tail -1)
   [ "$output" = "$root/file1.txt" ]
-  rm -rf "$root"
 }
 
 @test "file: navigate into directory and select" {
@@ -637,7 +636,6 @@ _setup_file_tree() {
     expect eof
   ' 2>&1 | clean_output | tail -1)
   [ "$output" = "$root/alpha/inner.txt" ]
-  rm -rf "$root"
 }
 
 @test "file: navigate up with .." {
@@ -657,7 +655,6 @@ _setup_file_tree() {
     expect eof
   ' 2>&1 | clean_output | tail -1)
   [ "$output" = "$root/file1.txt" ]
-  rm -rf "$root"
 }
 
 @test "file: q returns exit code 1" {
@@ -671,7 +668,6 @@ _setup_file_tree() {
     expect "EXIT:"
     expect eof
   ' 2>&1 | clean_output | grep -q "EXIT:1"
-  rm -rf "$root"
 }
 
 @test "file: ctrl-c returns exit code 130" {
@@ -685,7 +681,6 @@ _setup_file_tree() {
     expect "EXIT:"
     expect eof
   ' 2>&1 | clean_output | grep -q "EXIT:130"
-  rm -rf "$root"
 }
 
 @test "file: --filter shows only matching files" {
@@ -702,7 +697,6 @@ _setup_file_tree() {
     expect eof
   ' 2>&1 | clean_output | tail -1)
   [ "$output" = "$root/file1.txt" ]
-  rm -rf "$root"
 }
 
 @test "file: --dir mode select current directory" {
@@ -718,7 +712,6 @@ _setup_file_tree() {
     expect eof
   ' 2>&1 | clean_output | tail -1)
   [ "$output" = "$root" ]
-  rm -rf "$root"
 }
 
 @test "file: --dir mode navigate and select" {
@@ -738,7 +731,6 @@ _setup_file_tree() {
     expect eof
   ' 2>&1 | clean_output | tail -1)
   [ "$output" = "$root/alpha" ]
-  rm -rf "$root"
 }
 
 @test "file: --header shown in display" {
@@ -753,7 +745,6 @@ _setup_file_tree() {
     expect eof
   ' 2>&1 | clean_output | tail -1)
   [ "$output" = "$root/file1.txt" ]
-  rm -rf "$root"
 }
 
 @test "file: --var sets variable" {
@@ -768,5 +759,22 @@ _setup_file_tree() {
     expect eof
   ' 2>&1 | clean_output | grep "^RESULT:")
   [ "$output" = "RESULT:$root/file1.txt" ]
-  rm -rf "$root"
+}
+
+@test "file: unknown argument errors with exit 2" {
+  run chicle_file --fiter "*.txt"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"unknown argument: --fiter"* ]]
+}
+
+@test "file: --header without value errors with exit 2" {
+  run chicle_file --header
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"--header requires a value"* ]]
+}
+
+@test "file: --path to nonexistent directory errors with exit 1" {
+  run chicle_file --path /nonexistent-chicle-path-$$
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"no such directory"* ]]
 }

--- a/test/powershell/Chicle.Tests.ps1
+++ b/test/powershell/Chicle.Tests.ps1
@@ -242,3 +242,85 @@ Describe "Chicle-Progress" {
         }
     }
 }
+
+Describe "Chicle-File" {
+    BeforeEach {
+        $script:testRoot = Join-Path ([System.IO.Path]::GetTempPath()) "chicle_file_test_$([guid]::NewGuid().ToString('N'))"
+        New-Item -ItemType Directory -Path $script:testRoot -Force | Out-Null
+        New-Item -ItemType Directory -Path (Join-Path $script:testRoot "alpha") -Force | Out-Null
+        New-Item -ItemType Directory -Path (Join-Path $script:testRoot "alpha" "nested") -Force | Out-Null
+        New-Item -ItemType Directory -Path (Join-Path $script:testRoot "beta") -Force | Out-Null
+        "x" | Set-Content (Join-Path $script:testRoot "file1.txt")
+        "x" | Set-Content (Join-Path $script:testRoot "file2.sh")
+        "x" | Set-Content (Join-Path $script:testRoot "alpha" "inner.txt")
+        $global:chicleFileMockCount = 0
+    }
+
+    AfterEach {
+        Remove-Item -Recurse -Force $script:testRoot -ErrorAction SilentlyContinue
+    }
+
+    It "selects a file" {
+        Mock Chicle-Choose { "file1.txt" } -ModuleName chicle
+        $result = Chicle-File -Path $script:testRoot
+        $result | Should -BeExactly (Join-Path $script:testRoot "file1.txt")
+    }
+
+    It "navigates into directory and selects" {
+        Mock Chicle-Choose {
+            $global:chicleFileMockCount++
+            if ($global:chicleFileMockCount -eq 1) { "alpha/" }
+            else { "inner.txt" }
+        } -ModuleName chicle
+        $result = Chicle-File -Path $script:testRoot
+        $result | Should -BeExactly (Join-Path $script:testRoot "alpha" "inner.txt")
+    }
+
+    It "navigates up with .." {
+        Mock Chicle-Choose {
+            $global:chicleFileMockCount++
+            if ($global:chicleFileMockCount -eq 1) { ".." }
+            else { "file1.txt" }
+        } -ModuleName chicle
+        $result = Chicle-File -Path (Join-Path $script:testRoot "alpha")
+        $result | Should -BeExactly (Join-Path $script:testRoot "file1.txt")
+    }
+
+    It "returns null on quit" {
+        Mock Chicle-Choose { $null } -ModuleName chicle
+        $result = Chicle-File -Path $script:testRoot
+        $result | Should -BeNullOrEmpty
+    }
+
+    It "filters files with -Filter" {
+        Mock Chicle-Choose {
+            param([string]$Header, [string[]]$Options)
+            $Options | Should -Contain "file1.txt"
+            $Options | Should -Not -Contain "file2.sh"
+            "file1.txt"
+        } -ModuleName chicle
+        $result = Chicle-File -Path $script:testRoot -Filter "*.txt"
+        $result | Should -BeExactly (Join-Path $script:testRoot "file1.txt")
+    }
+
+    It "dir mode shows . entry and no files" {
+        Mock Chicle-Choose {
+            param([string]$Header, [string[]]$Options)
+            $Options | Should -Contain "."
+            $Options | Should -Not -Contain "file1.txt"
+            $Options | Should -Not -Contain "file2.sh"
+            "."
+        } -ModuleName chicle
+        $result = Chicle-File -Path $script:testRoot -Dir
+        $result | Should -BeExactly $script:testRoot
+    }
+
+    It "shows header in display" {
+        Mock Chicle-Choose {
+            param([string]$Header, [string[]]$Options)
+            $Header | Should -Match "Pick"
+            "file1.txt"
+        } -ModuleName chicle
+        Chicle-File -Path $script:testRoot -Header "Pick" | Out-Null
+    }
+}


### PR DESCRIPTION
Implements #11: interactive file/directory browser that reuses
chicle_choose under the hood. Supports --header, --dir, --filter,
--path, and --var flags. Directories are shown first with trailing /,
files are sorted alphabetically, and .. navigates up. In --dir mode
a . entry lets users select the current directory.

Bash tests use expect to drive real terminal navigation (10 tests).
PowerShell tests mock Chicle-Choose for unit-level coverage (7 tests).

https://claude.ai/code/session_01DumTjNTXqp47NUXsL7ZS7c